### PR TITLE
绑定FairWidget属性取值修改

### DIFF
--- a/fair/lib/src/bloc/common.dart
+++ b/fair/lib/src/bloc/common.dart
@@ -18,7 +18,7 @@ import '../widget.dart';
 FairWidgetBinding provider = () {
   return {
     'FairWidget': (props) => FairWidget(
-          name: props['type'],
+          name: props['name'],
           path: props['path'],
           data: props['data'],
         ),


### PR DESCRIPTION
嵌套使用FairWidget的时候发现动态生成的FairWidget中name一直是空的，经排查发现是binding的时候取值有问题