### PR TITLE
发布 dart2dsl 和 dart2js 到 pub.dev

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -1,8 +1,11 @@
-## [2.3.0]
-* Add null-safety
+## [1.0.1]
+* bugfix.
+
+## [1.0.0]
+* Add null-safety.
 
 ## [0.3.0+1]
-* bug fix
+* bugfix.
 
 ## [0.3.0]
 * Minimize size of assets.

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,1 @@
+A complier which can generate Fair bundle for widget with annotation.

--- a/compiler/lib/src/helper.dart
+++ b/compiler/lib/src/helper.dart
@@ -12,7 +12,7 @@ import 'package:fair_compiler/src/fair_asset.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
-import 'package:fairc/fairc.dart' as dart2dsl;
+import 'package:fair_dart2dsl/fairc.dart' as dart2dsl;
 
 mixin FlatCompiler {
   final command = 'flatc';

--- a/compiler/lib/src/post_builder.dart
+++ b/compiler/lib/src/post_builder.dart
@@ -13,7 +13,7 @@ import 'package:build/build.dart';
 import 'package:crypto/crypto.dart' show md5;
 import 'package:fair_compiler/src/state_transfer.dart';
 import 'package:path/path.dart' as path;
-import 'package:dartToJs/index.dart' as dart2js;
+import 'package:fair_dart2js/index.dart' as dart2js;
 import 'helper.dart' show FlatCompiler, ModuleNameHelper;
 
 class ArchiveBuilder extends PostProcessBuilder with FlatCompiler {

--- a/compiler/pubspec.yaml
+++ b/compiler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fair_compiler
 description: A complier which can generate Fair bundle for widget with annotation.
-version: 2.3.0
+version: 1.0.1
 homepage: https://fair.58.com/
 
 environment:
@@ -25,10 +25,8 @@ dependencies:
 #  fair_annotation:
 #    path: ../annotation
   http: ^0.13.3
-  fairc:
-    path: ../dart2dsl
-  dartToJs:
-    path: ../dart2js
+  fair_dart2dsl: ^1.0.1
+  fair_dart2js: ^1.0.0
 
 dev_dependencies:
   test: ^1.17.12

--- a/dart2dsl/CHANGELOG.md
+++ b/dart2dsl/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- bugfix.
+
 ## 1.0.0
 
-- Initial version, created by Stagehand
+- Initial version, created by Stagehand.

--- a/dart2dsl/LICENSE
+++ b/dart2dsl/LICENSE
@@ -1,0 +1,25 @@
+Copyright (C) 2005-present, 58.com.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of 58.com nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dart2dsl/README.md
+++ b/dart2dsl/README.md
@@ -1,7 +1,6 @@
-# Fair Compiler
-Fair SDK的配套编译器，简称`fairc`；核心功能
+# fair_dart2dsl
 
-> 区别于Fair SDK, Fair Compiler为提效核心目前闭源，对使用者提编译后可行性产物
+fair_compiler 的配套编译器，用于将 Dart 转为 DSL。
 
 * 基于dart业务代码，编译生成json，bin格式的bundle资源
 * 基于基于用户注解，生成自定义、三方组件的dart源码

--- a/dart2dsl/build.yaml
+++ b/dart2dsl/build.yaml
@@ -1,6 +1,6 @@
 builders:
   ast_node_map_builder:
-    import: 'package:fairc/fairdsl/fair_ast_check_gen.dart'
+    import: 'package:fair_dart2dsl/fairdsl/fair_ast_check_gen.dart'
     builder_factories: ['AstNodeMapBuilder']
     build_extensions: { '.dart': ['.g.dart'] }
     auto_apply: root_package

--- a/dart2dsl/lib/fairdsl/fair_ast_node.dart
+++ b/dart2dsl/lib/fairdsl/fair_ast_node.dart
@@ -6,7 +6,7 @@
 
 import 'dart:io';
 
-import 'package:fairc/fairdsl/fair_ast_logic_unit.dart';
+import 'package:fair_dart2dsl/fairdsl/fair_ast_logic_unit.dart';
 
 enum AstNodeName {
   Identifier,

--- a/dart2dsl/lib/fairdsl/fair_dsl_gen.dart
+++ b/dart2dsl/lib/fairdsl/fair_dsl_gen.dart
@@ -5,7 +5,8 @@
  */
 
 import 'dart:convert';
-import 'package:fairc/fairdsl/fair_ast_logic_unit.dart';
+
+import 'package:fair_dart2dsl/fairdsl/fair_ast_logic_unit.dart';
 
 import 'fair_ast_node.dart';
 

--- a/dart2dsl/lib/src/widget.dart
+++ b/dart2dsl/lib/src/widget.dart
@@ -12,9 +12,9 @@ import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:path/path.dart';
 import 'package:analyzer/src/dart/ast/ast.dart';
 import 'package:analyzer/src/dart/element/element.dart';
+import 'package:path/path.dart';
 import 'transformer.dart';
 
 var baseWidget = [

--- a/dart2dsl/pubspec.yaml
+++ b/dart2dsl/pubspec.yaml
@@ -1,7 +1,7 @@
-name: fairc
-description: A sample command-line application.
-# version: 1.0.0
-# homepage: https://www.example.com
+name: fair_dart2dsl
+description: Companion compiler for fair_compiler for converting Dart to DSL.
+version: 1.0.1
+homepage: https://fair.58.com/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,9 +9,12 @@ executables:
   fairc:
 dependencies:
   analyzer: ^2.3.0
+  path: ^1.8.0
+  args: ^2.3.0
+  source_gen: ^1.2.2
+  build: ^2.1.0
 
 dev_dependencies:
   pedantic: ^1.11.1
   test: ^1.17.12
-  source_gen: ^1.2.2
   build_runner: ^2.1.2

--- a/dart2js/CHANGELOG.md
+++ b/dart2js/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version, created by Stagehand

--- a/dart2js/LICENSE
+++ b/dart2js/LICENSE
@@ -1,0 +1,25 @@
+Copyright (C) 2005-present, 58.com.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of 58.com nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dart2js/README.md
+++ b/dart2js/README.md
@@ -1,0 +1,3 @@
+# fair_dart2js
+
+fair_compiler 的配套编译器，用于将 Dart 转为 JS。

--- a/dart2js/lib/src/__test_data__/page1/page1.dart
+++ b/dart2js/lib/src/__test_data__/page1/page1.dart
@@ -4,12 +4,12 @@
  * found in the LICENSE file.
  */
 
-import 'package:fair/fair.dart';
+// import 'package:fair/fair.dart';
 import 'package:flutter/material.dart';
 
 import 'custom_func.dart' as a;
 
-@FairPatch()
+// @FairPatch()
 class SampleLogicPage2Page extends StatefulWidget {
   var _props;
 
@@ -22,7 +22,7 @@ class SampleLogicPage2Page extends StatefulWidget {
 }
 
 class _Page2PageState extends State<SampleLogicPage2Page> {
-  @FairProps()
+  // @FairProps()
   var fairProps;
 
   var _count;

--- a/dart2js/lib/src/convertor.dart
+++ b/dart2js/lib/src/convertor.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
-import 'package:dartToJs/src/list_ext.dart';
+import 'package:fair_dart2js/src/list_ext.dart';
 import 'package:path/path.dart' as p;
 
 enum ClassOutputTemplateType { raw, pageState }

--- a/dart2js/pubspec.yaml
+++ b/dart2js/pubspec.yaml
@@ -1,9 +1,12 @@
-name: dartToJs
+name: fair_dart2js
 description: Convert individual dart file to js.
-# version: 1.0.0
+version: 1.0.0
+homepage: https://fair.58.com/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 dependencies:
+  flutter:
+    sdk: flutter
   analyzer: ^2.3.0
   path: ^1.8.0


### PR DESCRIPTION
1. 发布 dart2dsl 工程到 pub.dev，名称为：[fair_dart2dsl](https://pub.dev/packages/fair_dart2dsl/install)
2. 发布 dart2js 工程到 pub.dev，名称为：[fair_dart2js](https://pub.dev/packages/fair_dart2js)
3. 发布 compiler 工程到 pub.dev，名称为：[fair_compiler](https://pub.dev/packages/fair_compiler)
