### PR TITLE
catch语句在iOS10报错问题修复

### DIFF
--- a/fair/assets/fair_core/fair_jsbase.js
+++ b/fair/assets/fair_core/fair_jsbase.js
@@ -754,7 +754,7 @@ Object.__inner__ = function () {};
   DateTime.tryParse = function (formattedString) {
     try {
       return DateTime.parse(formattedString);
-    } catch {
+    } catch (err) {
       return null;
     }
   };


### PR DESCRIPTION
在iOS10系统上catch语句后面不加上(err)会导致错误Unexpected token '{'. Expected '(' to start a 'catch' target。导致后续的js语句都无法执行。