### PR TITLE
fix example compile error due to stack overflow has been removed

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()

--- a/example/lib/best_flutter_ui/fitness_app/ui_view/glass_view.dart
+++ b/example/lib/best_flutter_ui/fitness_app/ui_view/glass_view.dart
@@ -25,7 +25,7 @@ class GlassView extends StatelessWidget {
                   padding: const EdgeInsets.only(
                       left: 24, right: 24, top: 0, bottom: 24),
                   child: Stack(
-                    overflow: Overflow.visible,
+                    clipBehavior: Clip.none,
                     children: <Widget>[
                       Padding(
                         padding: const EdgeInsets.only(top: 16),

--- a/example/lib/best_flutter_ui/fitness_app/ui_view/mediterranesn_diet_view.dart
+++ b/example/lib/best_flutter_ui/fitness_app/ui_view/mediterranesn_diet_view.dart
@@ -256,7 +256,7 @@ class MediterranesnDietView extends StatelessWidget {
                             padding: const EdgeInsets.only(right: 16),
                             child: Center(
                               child: Stack(
-                                overflow: Overflow.visible,
+                                clipBehavior: Clip.none,
                                 children: <Widget>[
                                   Padding(
                                     padding: const EdgeInsets.all(8.0),

--- a/example/lib/best_flutter_ui/fitness_app/ui_view/running_view.dart
+++ b/example/lib/best_flutter_ui/fitness_app/ui_view/running_view.dart
@@ -24,7 +24,7 @@ class RunningView extends StatelessWidget {
                   padding: const EdgeInsets.only(
                       left: 24, right: 24, top: 0, bottom: 0),
                   child: Stack(
-                    overflow: Overflow.visible,
+                    clipBehavior: Clip.none,
                     children: <Widget>[
                       Padding(
                         padding: const EdgeInsets.only(top: 16, bottom: 16),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:fair/fair.dart';

--- a/fair/android/build.gradle
+++ b/fair/android/build.gradle
@@ -9,7 +9,7 @@ group 'com.wuba.fair'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Stack overflow already deprecated and removed, this PR fix compile errors. See flutter/flutter#66305 & flutter/flutter#98583.