### PR TITLE
修复 _reload 方法中调用 context 报错

### DIFF
--- a/fair/lib/src/widget.dart
+++ b/fair/lib/src/widget.dart
@@ -138,14 +138,21 @@ class FairState extends State<FairWidget> with Loader, AutomaticKeepAliveClientM
   }
 
   void _reload() {
-    var name = state2key;
-    var path = widget.path ?? _fairApp!.pathOfBundle(widget.name??'');
-    bundleType = widget.path != null && widget.path?.startsWith('http')==true ? 'Http' : 'Asset';
-    parse(context, page: name, url: path, data: widget.data??{}).then((value) {
-      if (mounted && value != null) {
-        setState(() => _child = value);
-      }
-    });
+    if (mounted) {
+      var name = state2key;
+      var path = widget.path ?? _fairApp!.pathOfBundle(widget.name ?? '');
+      bundleType =
+          widget.path != null && widget.path?.startsWith('http') == true
+              ? 'Http'
+              : 'Asset';
+
+      parse(context, page: name, url: path, data: widget.data ?? {})
+          .then((value) {
+        if (mounted && value != null) {
+          setState(() => _child = value);
+        }
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
 _resolveFairRes 方法在 didChangeDependencies 当中调用，但是 _resolveFairRes 不是同步方法，不能保证调用 _reload 方法时候， context 还在树上面。

所以需要增加判断。