### PR TITLE
修改 安卓 Fair minSdkVersion 版本

### DIFF
--- a/fair/android/build.gradle
+++ b/fair/android/build.gradle
@@ -32,7 +32,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
从 19 修改 为 16，flutter 自身的限制没有这么高，会导致安卓运行不起来