### PR TITLE
FairWidget 的 key 不应该写死默认的

### DIFF
--- a/fair/lib/src/widget.dart
+++ b/fair/lib/src/widget.dart
@@ -77,7 +77,7 @@ class FairWidget extends StatefulWidget {
           }
           return true;
         }(), ''),
-        super(key: key ?? ObjectKey(path ?? name));
+        super(key: key);
 
   @override
   State<StatefulWidget> createState() => FairState();


### PR DESCRIPTION
是否定义，应该交由用户决定。在列表中。使用重复key 会导致重新build