### PR TITLE
修复 #244 IconData 导致的无法做 tree-shake-icons

### DIFF
--- a/dart2dsl/lib/src/widget.dart
+++ b/dart2dsl/lib/src/widget.dart
@@ -657,6 +657,15 @@ bool _invalidElement(Element element) {
   return isVisibleForTesting != null && isVisibleForTesting.isNotEmpty;
 }
 
+/// 跳过的类型
+var _blackList = [
+   /// It has non-constant instances of IconData
+   /// https://github.com/wuba/Fair/issues/244
+   /// IconData 不经常使用，不移除的话，Flutter 没法做 tree-shake-icons, 这会导致包体积进一步增大
+   /// 如果用户真的要用到，自定义 binding 并且使用 --no-tree-shake-icons 命令打包即可
+   'IconData',
+];
+
 ///
 /// We need to compile all of constructions when compile the SDK files.
 ///
@@ -666,6 +675,9 @@ List<ClassExposed> _visit(CompilationUnitElement? unitElement, [bool isSdk = fal
   // 枚举与class不同
   var apis = [...unitElement.classes, ...unitElement.enums];
   for (var classElement in apis) {
+    if(classElement is ClassElement && _blackList.contains(classElement.name)) {
+      continue; 
+    }
     if ((classElement is ClassElement && classElement.isAbstract) || _invalidElement(classElement) || classElement.isSynthetic) {
       print('skip ' + classElement.name);
       continue;

--- a/fair/lib/src/bloc/common.dart
+++ b/fair/lib/src/bloc/common.dart
@@ -81,13 +81,5 @@ FairWidgetBinding provider = () {
         color: props['color'],
         width: props['width'],
         style: props['style'] ?? BorderStyle.solid),
-    'IconData': (props) {
-      // const Map pro = Map.from(props);
-      return IconData(
-        int.parse(props['pa'][0]),
-        fontFamily: props['fontFamily'],
-        fontPackage: props['fontPackage'],
-      );
-    },
   };
 };

--- a/flutter_version/flutter_3_0_0/lib/src/widgets/$$w.dart
+++ b/flutter_version/flutter_3_0_0/lib/src/widgets/$$w.dart
@@ -3645,11 +3645,6 @@ var p = () => {
             semanticLabel: props['semanticLabel'],
             textDirection: props['textDirection'],
       ),
-      'IconData': (props) => IconData(
-            props['pa'][0],
-            fontFamily: props['fontFamily'],
-            fontPackage: props['fontPackage'],
-      ),
       'Visibility': (props) => Visibility(
             key: props['key'],
             child: props['child'],

--- a/flutter_version/flutter_3_0_0/lib/src/widgets/version.dart
+++ b/flutter_version/flutter_3_0_0/lib/src/widgets/version.dart
@@ -578,7 +578,6 @@ const widgetNames = {
   'AnimationStatus': false,
   'CatmullRomCurve': false,
   'Curves': false,
-  'IconData': true,
   'AlwaysScrollableScrollPhysics': false,
   'ClampingScrollPhysics': false,
   'FixedExtentScrollPhysics': false,


### PR DESCRIPTION
fix #244 
IconData 不经常使用，不移除的话，Flutter 没法做 tree-shake-icons, 这会导致包体积进一步增大
如果用户真的要用到，自定义 binding 并且使用 --no-tree-shake-icons 命令打包即可.

注意这个是一个breaking change，如果merge 了，changelog 里面要注重标记。