### PR TITLE
支持嵌套的 domain，提供通用的 FunctionDomain来支持任意回调。

### DIFF
--- a/dart2dsl/lib/fairdsl/fair_ast_gen.dart
+++ b/dart2dsl/lib/fairdsl/fair_ast_gen.dart
@@ -195,7 +195,13 @@ class CustomAstVisitor extends SimpleAstVisitor<Map> {
   Map? visitSimpleFormalParameter(SimpleFormalParameter node) {
     // return _buildSimpleFormalParameter(
     //     _visitNode(node.type), node.identifier?.name);
-    return _buildSimpleFormalParameter(_visitNode(node.type), node.name?.lexeme);
+    return _buildSimpleFormalParameter(_visitNode(node.type), node.name?.lexeme,node.isNamed);
+  }
+
+  @override
+  Map? visitDefaultFormalParameter(DefaultFormalParameter node) {
+    var type= (node.parameter as SimpleFormalParameter?)?.type;
+    return _buildSimpleFormalParameter(_visitNode(type), node.name?.lexeme,node.isNamed);
   }
 
   @override
@@ -383,8 +389,13 @@ class CustomAstVisitor extends SimpleAstVisitor<Map> {
   Map _buildFormalParameterList(List<Map> parameterList) => {'type': 'FormalParameterList', 'parameterList': parameterList};
 
   //函数参数
-  Map _buildSimpleFormalParameter(Map? type, String? name) => {'type': 'SimpleFormalParameter', 'paramType': type, 'name': name};
-
+  //函数参数
+  Map _buildSimpleFormalParameter(Map? type, String? name, bool isNamed) => {
+        'type': 'SimpleFormalParameter',
+        'paramType': type,
+        'name': name,
+        'isNamed': isNamed,
+      };
   //函数参数类型
   Map _buildTypeName(String name) => {
         'type': 'TypeName',

--- a/dart2dsl/lib/fairdsl/fair_ast_node.dart
+++ b/dart2dsl/lib/fairdsl/fair_ast_node.dart
@@ -298,14 +298,16 @@ class MemberExpression extends AstNode {
 class SimpleFormalParameter extends AstNode {
   TypeName? paramType;
   String? name;
+  bool? isNamed;
 
-  SimpleFormalParameter(this.paramType, this.name, {Map? ast}) : super(ast: ast);
+  SimpleFormalParameter(this.paramType, this.name, this.isNamed, {Map? ast})
+      : super(ast: ast);
 
   static SimpleFormalParameter? fromAst(Map? ast) {
     if (ast != null &&
         ast['type'] == astNodeNameValue(AstNodeName.SimpleFormalParameter)) {
       return SimpleFormalParameter(
-          TypeName.fromAst(ast['paramType']), ast['name'],
+          TypeName.fromAst(ast['paramType']), ast['name'], ast['isNamed'],
           ast: ast);
     }
     return null;

--- a/dart2dsl/lib/fairdsl/fair_check_node_map.dart
+++ b/dart2dsl/lib/fairdsl/fair_check_node_map.dart
@@ -6,13 +6,13 @@
 
 // **************************************************************************
 // 如果存在新文件需要更新，建议先执行清除命令：
-// flutter packages pub run build_runner clean 
-// 
+// flutter packages pub run build_runner clean
+//
 // 然后执行下列命令重新生成相应文件：
-// flutter packages pub run build_runner build --delete-conflicting-outputs 
+// flutter packages pub run build_runner build --delete-conflicting-outputs
 // 自动生成请勿修改
 // **************************************************************************
-final checkNode={
+final checkNode = {
   'DeclaredSimpleIdentifier': 'DeclaredSimpleIdentifier',
   'ConstructorDeclarationImpl': 'ConstructorDeclarationImpl',
   'InterpolationStringImpl': 'InterpolationStringImpl',
@@ -39,8 +39,9 @@ final checkNode={
   'ExpressionFunctionBodyImpl': 'visitExpressionFunctionBody',
   'FunctionExpressionImpl': 'visitFunctionExpression',
   'SimpleFormalParameterImpl': 'visitSimpleFormalParameter',
+  'DefaultFormalParameterImpl': 'visitDefaultFormalParameter',
   'FormalParameterListImpl': 'visitFormalParameterList',
-  'TypeNameImpl': 'visitTypeName',
+  'NamedTypeImpl': 'visitNamedType',
   'ReturnStatementImpl': 'visitReturnStatement',
   'MethodDeclarationImpl': 'visitMethodDeclaration',
   'NamedExpressionImpl': 'visitNamedExpression',
@@ -55,6 +56,5 @@ final checkNode={
   'ExtendsClauseImpl': 'visitExtendsClause',
   'ImplementsClauseImpl': 'visitImplementsClause',
   'WithClauseImpl': 'visitWithClause',
-  'PropertyAccessImpl': 'visitPropertyAccess',
-  'IndexExpressionImpl': 'visitIndexExpression'
+  'PropertyAccessImpl': 'visitPropertyAccess'
 };

--- a/dart2dsl/lib/fairdsl/fair_dsl_gen.dart
+++ b/dart2dsl/lib/fairdsl/fair_dsl_gen.dart
@@ -391,6 +391,22 @@ dynamic _buildValueExpression(
       naPaValue = _buildValueExpression(
           valueExpression?.asFunctionExpression.body?.body?.last, fairDslContex);
     }
+    if (naPaValue is Map && valueExpression?.asFunctionExpression.parameterList != null &&
+        valueExpression!.asFunctionExpression.parameterList!.isNotEmpty) {
+      var na = [];
+      var pa = [];
+      for (var element in valueExpression.asFunctionExpression.parameterList!) {
+        if (element?.isNamed == true) {
+          na.add(element?.name);
+        } else {
+          pa.add(element?.name);
+        }
+      }
+      naPaValue['functionParameters'] = {
+        if (na.isNotEmpty) 'na': na,
+        if (pa.isNotEmpty) 'pa': pa,
+      };
+    }    
   } else if (valueExpression?.isReturnStatement==true) {
     naPaValue = _buildValueExpression(
         valueExpression?.asReturnStatement.argument, fairDslContex);

--- a/fair/lib/src/bloc/flow.dart
+++ b/fair/lib/src/bloc/flow.dart
@@ -32,19 +32,6 @@ FairWidgetBinding provider = () {
       assert(items is List, 'failed to generate list of Sugar.map');
       return (((items as List).asIteratorOf<Widget>() ?? items) as Iterable).toList();
     },
-    'Sugar.ifEqual': (props) {
-      var p0 = pa0(props);
-      var p1 = pa1(props);
-      if (p0.runtimeType != p1.runtimeType) {
-        p0 = '$p0';
-        p1 = '$p1';
-      }
-      return p0 == p1 ? props['trueValue'] : props['falseValue'];
-    },
-    'Sugar.ifEqualBool': (props) {
-      var state = pa0(props);
-      return state ? props['trueValue'] : props['falseValue'];
-    },
     'Sugar.ifRange': (props) {
       var p0 = pa0(props);
       var p1 = pa1(props);
@@ -89,18 +76,6 @@ FairWidgetBinding provider = () {
         sugarCase: p0,
         reValue: p1,
       );
-    },
-    'Sugar.switchCase':(props){
-      var p0 = pa0(props);
-      List p1 = (pa1(props) as List);
-      var p2 = pa2(props);
-      for (var sugarCase in p1){
-        var caseValue = sugarCase as SugarSwitchCaseObj;
-        if (caseValue.sugarCase == p0){
-          return caseValue.reValue;
-        }
-      }
-      return p2;
     },
     'Sugar.popMenuButton': (props) {
       var p0 = pa0(props);

--- a/fair/lib/src/experiment/sugar.dart
+++ b/fair/lib/src/experiment/sugar.dart
@@ -42,7 +42,8 @@ class Sugar {
   }
 
   /// Map operation without index
-  static List<T> map<T, E>(List<E> data, {required T Function(E item) builder}) {
+  static List<T> map<T, E>(List<E> data,
+      {required T Function(E item) builder}) {
     return data.mapEach((index, item) => builder(item));
   }
 
@@ -64,14 +65,15 @@ class Sugar {
     double? cacheExtent,
     int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
     String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
     required IndexedWidgetBuilder itemBuilder,
     int? itemCount,
-  }){
+  }) {
     return ListView.builder(
-      key: key,
+        key: key,
         scrollDirection: scrollDirection,
         reverse: reverse,
         controller: controller,
@@ -91,13 +93,15 @@ class Sugar {
         restorationId: restorationId,
         clipBehavior: clipBehavior,
         itemCount: itemCount,
-        itemBuilder:itemBuilder);
+        itemBuilder: itemBuilder);
   }
-  static NestedScrollViewHeaderSliversBuilder isNestedScrollViewHeaderSliversBuilder({
-    required BuildContext context,
-    required bool innerBoxIsScrolled,
-    required List<Widget> headerSliverBuilder}){
-    return (BuildContext context, bool innerBoxIsScrolled){
+
+  static NestedScrollViewHeaderSliversBuilder
+      isNestedScrollViewHeaderSliversBuilder(
+          {required BuildContext context,
+          required bool innerBoxIsScrolled,
+          required List<Widget> headerSliverBuilder}) {
+    return (BuildContext context, bool innerBoxIsScrolled) {
       return headerSliverBuilder;
     };
   }
@@ -123,7 +127,7 @@ class Sugar {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
-  }){
+  }) {
     return ButtonStyle(
       textStyle: MaterialStateProperty.all<TextStyle?>(textStyle),
       backgroundColor: MaterialStateProperty.all(backgroundColor),
@@ -147,40 +151,41 @@ class Sugar {
       splashFactory: splashFactory,
     );
   }
-  static Duration isDuration({
-    int days = 0,
-    int hours = 0,
-    int minutes = 0,
-    int seconds = 0,
-    int milliseconds = 0,
-    int microseconds = 0}){
+
+  static Duration isDuration(
+      {int days = 0,
+      int hours = 0,
+      int minutes = 0,
+      int seconds = 0,
+      int milliseconds = 0,
+      int microseconds = 0}) {
     return Duration(
-        hours:hours,
-        minutes:minutes,
-        seconds:seconds,
-        milliseconds:milliseconds,
-        microseconds:microseconds,
+      hours: hours,
+      minutes: minutes,
+      seconds: seconds,
+      milliseconds: milliseconds,
+      microseconds: microseconds,
     );
   }
+
   ///popmenu
-  static PopupMenuButton popMenuButton<T>({
-    Key? key,
-    required PopupMenuItemBuilder<T> itemBuilder,
-    PopupMenuItemSelected<T>? onSelected,
-    T? initialValue,
-    EdgeInsetsGeometry padding = const EdgeInsets.all(8.0),
-    PopupMenuCanceled? onCanceled,
-    String? tooltip,
-    double? elevation,
-    Widget? child,
-    Widget? icon,
-    double? iconSize,
-    ShapeBorder? shape,
-    Offset offset = Offset.zero ,
-    bool enabled = true,
-    Color? color,
-    bool? enableFeedback
-  }){
+  static PopupMenuButton popMenuButton<T>(
+      {Key? key,
+      required PopupMenuItemBuilder<T> itemBuilder,
+      PopupMenuItemSelected<T>? onSelected,
+      T? initialValue,
+      EdgeInsetsGeometry padding = const EdgeInsets.all(8.0),
+      PopupMenuCanceled? onCanceled,
+      String? tooltip,
+      double? elevation,
+      Widget? child,
+      Widget? icon,
+      double? iconSize,
+      ShapeBorder? shape,
+      Offset offset = Offset.zero,
+      bool enabled = true,
+      Color? color,
+      bool? enableFeedback}) {
     return PopupMenuButton<T>(
       key: key,
       itemBuilder: itemBuilder,
@@ -213,36 +218,41 @@ class Sugar {
 
   static Color colorWithOpacity = Colors.grey.withOpacity(0.8);
 
-  static Color colorsWithOpacity(Color c,double o){
+  static Color colorsWithOpacity(Color c, double o) {
     return c.withOpacity(o);
   }
-  static Color colorsShade( MaterialColor color, int i){
-    var shadeMap={
-      50:color.shade50,
-      100:color.shade100,
-      200:color.shade200,
-      300:color.shade300,
-      400:color.shade400,
-      500:color.shade500,
-      600:color.shade600,
-      700:color.shade700,
-      800:color.shade800,
-      900:color.shade900,
+
+  static Color colorsShade(MaterialColor color, int i) {
+    var shadeMap = {
+      50: color.shade50,
+      100: color.shade100,
+      200: color.shade200,
+      300: color.shade300,
+      400: color.shade400,
+      500: color.shade500,
+      600: color.shade600,
+      700: color.shade700,
+      800: color.shade800,
+      900: color.shade900,
     };
     return shadeMap.remove(i) as Color;
   }
 
-  static String convertToString<T>({required T orginalValue}){
+  static String convertToString<T>({required T orginalValue}) {
     return orginalValue.toString();
   }
 
-  static double height(BuildContext context) => MediaQuery.of(context).size.height;
+  static double height(BuildContext context) =>
+      MediaQuery.of(context).size.height;
 
-  static double width(BuildContext context) => MediaQuery.of(context).size.width;
+  static double width(BuildContext context) =>
+      MediaQuery.of(context).size.width;
 
-  static double paddingTop(BuildContext context) => MediaQuery.of(context).padding.top;
+  static double paddingTop(BuildContext context) =>
+      MediaQuery.of(context).padding.top;
 
-  static double paddingBottom(BuildContext context) => MediaQuery.of(context).padding.bottom;
+  static double paddingBottom(BuildContext context) =>
+      MediaQuery.of(context).padding.bottom;
 
   static Null Function() requestFocus(BuildContext context) => () {
         FocusScope.of(context).requestFocus(FocusNode());
@@ -251,24 +261,21 @@ class Sugar {
   static Null Function() onTapEmpty() => () {};
 
   /*CustomScrollView-common-delegate*/
-  static SliverChildBuilderDelegate sliverChildBuilderDelegate({
-    Key? key,
-    required NullableIndexedWidgetBuilder builder,
-    int? childCount
-  }) {
-    return SliverChildBuilderDelegate((builder),
-        childCount: childCount
-    );
+  static SliverChildBuilderDelegate sliverChildBuilderDelegate(
+      {Key? key,
+      required NullableIndexedWidgetBuilder builder,
+      int? childCount}) {
+    return SliverChildBuilderDelegate((builder), childCount: childCount);
   }
-  /*CustomScrollView-SliverGrid*/
-  static SliverGridDelegateWithFixedCrossAxisCount sliverGridDelegateWithFixedCrossAxisCount(
-      {
-        required int crossAxisCount,
-        double mainAxisSpacing = 0.0,
-        double crossAxisSpacing = 0.0,
-        double childAspectRatio = 1.0,
 
-      }) {
+  /*CustomScrollView-SliverGrid*/
+  static SliverGridDelegateWithFixedCrossAxisCount
+      sliverGridDelegateWithFixedCrossAxisCount({
+    required int crossAxisCount,
+    double mainAxisSpacing = 0.0,
+    double crossAxisSpacing = 0.0,
+    double childAspectRatio = 1.0,
+  }) {
     return SliverGridDelegateWithFixedCrossAxisCount(
       crossAxisCount: crossAxisCount, //Grid按两列显示
       mainAxisSpacing: mainAxisSpacing,
@@ -276,6 +283,19 @@ class Sugar {
       childAspectRatio: childAspectRatio,
     );
   }
+
+  static NullableIndexedWidgetBuilder nullableIndexedWidgetBuilder(
+          NullableIndexedWidgetBuilder builder) =>
+      builder;
+
+  static IndexedWidgetBuilder indexedWidgetBuilder(
+          IndexedWidgetBuilder builder) =>
+      builder;
+
+  static WidgetBuilder widgetBuilder(WidgetBuilder builder) => builder;
+
+  static TransitionBuilder transitionBuilder(TransitionBuilder builder) =>
+      builder;
 }
 
 class SugarSwitchCaseObj<T, K> {

--- a/fair/lib/src/internal/bind_data.dart
+++ b/fair/lib/src/internal/bind_data.dart
@@ -25,7 +25,8 @@ class BindingData {
   BindingData(this.modules,
       {this.data,
       Map<String, Function>? functions,
-      Map<String, PropertyValue>? values, Map<String, PropertyValue>? delegateValues})
+      Map<String, PropertyValue>? values,
+      Map<String, PropertyValue>? delegateValues})
       : _functions = functions,
         _values = values,
         super();
@@ -46,10 +47,11 @@ class BindingData {
       var result;
       if (RegExp(r'.+\(.+\)', multiLine: false).hasMatch(funcName)) {
         var rFuncName = funcName.substring(0, funcName.indexOf('('));
-        var params =
-        funcName.substring(funcName.indexOf('(') + 1 , funcName.lastIndexOf(')'));
+        var params = funcName.substring(
+            funcName.indexOf('(') + 1, funcName.lastIndexOf(')'));
         var args = params.split(',').map((e) {
-          if (RegExp(r'\^\(index\)', multiLine: false).hasMatch(e)) {
+          if (RegExp(r'\^\(index\)', multiLine: false).hasMatch(e) &&
+              domain is IndexDomain?) {
             return domain?.index;
           } else if (domain != null && domain.match(e)) {
             return domain.bindValue(e);
@@ -75,7 +77,8 @@ class BindingData {
 
   dynamic bindFunctionOf(String funcName) {
     if (_functions?[funcName] == null) {
-      return ([props]) => _functions?['runtimeInvokeMethod']?.call(funcName, props);
+      return ([props]) =>
+          _functions?['runtimeInvokeMethod']?.call(funcName, props);
     } else {
       return _functions?[funcName];
     }

--- a/fair/lib/src/render/builder.dart
+++ b/fair/lib/src/render/builder.dart
@@ -79,9 +79,9 @@ class DynamicWidgetBuilder extends DynamicBuilder {
       }
       assert(mapper != null, '$name is not registered!');
       if (name == 'Sugar.mapEach') {
-        return _buildSugarMapEach(mapper, map, methodMap, context);
+        return _buildSugarMapEach(mapper, map, methodMap, context, domain);
       } else if (name == 'Sugar.map') {
-        return _buildSugarMap(mapper, map, methodMap, context);
+        return _buildSugarMap(mapper, map, methodMap, context, domain);
       } else if (name == 'Sugar.listBuilder') {
         return _buildSugarListBuilder(
             name, domain, mapper, map, methodMap, context);
@@ -262,8 +262,8 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     return children;
   }
 
-  W namedString(String tag, dynamic naMap, Map? methodMap,
-      BuildContext context, Domain? domain, String v) {
+  W namedString(String tag, dynamic naMap, Map? methodMap, BuildContext context,
+      Domain? domain, String v) {
     var result;
     var needBinding = false;
     var body;
@@ -284,18 +284,13 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   }
 
   List<Widget> _buildSugarMapEach(
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
-    dynamic source = pa0(map);
-    var children = [];
-    if (source is String) {
-      var r = proxyMirror?.evaluate(context, bound, source);
-      if (r?.data != null) {
-        source = r?.data;
-      }
-    }
-    else if(source is Map) {
-      source = convert(context, source, methodMap);
-    }
+    Function mapEach,
+    Map map,
+    Map? methodMap,
+    BuildContext context,
+    Domain? domain,
+  ) {
+    dynamic source = p0Value(pa0(map), methodMap, context, domain);
 
     if (!(source is List)) {
       throw Exception('Sugar.mapEach has no valid source array');
@@ -313,6 +308,8 @@ class DynamicWidgetBuilder extends DynamicBuilder {
         }
       });
     }
+
+    var children = [];
     //转为Widget
     if (source is List) {
       children = Domain(source).forEach(($, _) {
@@ -326,19 +323,13 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   }
 
   List<Widget> _buildSugarMap(
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
-    var source = pa0(map);
-    var children = [];
-    if (source is String) {
-      var r = proxyMirror?.evaluate(context, bound, source);
-      if (r?.data != null) {
-        source = r?.data;
-      }
-    }
-    else if(source is Map) {
-      source = convert(context, source, methodMap);
-    }
-
+    Function mapEach,
+    Map map,
+    Map? methodMap,
+    BuildContext context,
+    Domain? domain,
+  ) {
+    dynamic source = p0Value(pa0(map), methodMap, context, domain);
 
     if (!(source is List)) {
       throw Exception('Sugar.mapEach has no valid source array');
@@ -356,7 +347,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
         }
       });
     }
-
+    var children = [];
     if (source is List) {
       children = Domain(source).forEach(($, _) {
         return convert(context, map['na']['builder'], methodMap, domain: $);

--- a/fair/lib/src/render/builder.dart
+++ b/fair/lib/src/render/builder.dart
@@ -1,3 +1,6 @@
+
+// ignore_for_file: omit_local_variable_types
+
 /*
  * Copyright (C) 2005-present, 58.com.  All rights reserved.
  * Use of this source code is governed by a BSD type license that can be
@@ -114,6 +117,34 @@ class DynamicWidgetBuilder extends DynamicBuilder {
       } else if (name == 'Sugar.sliverGridDelegateWithFixedCrossAxisCount') {
         return _buildSugarSliverGridDelegateWithFixedCrossAxisCount(
             mapper, map, methodMap, context);
+      } else if (name == 'Sugar.nullableIndexedWidgetBuilder') {
+        return _buildSugarNullableIndexedWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.indexedWidgetBuilder') {
+        return _buildSugarIndexedWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.widgetBuilder') {
+        return _buildSugarWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.transitionBuilder') {
+        return _buildSugarTransitionBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
       }
 
       var source = map['mapEach'];
@@ -309,31 +340,37 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     BuildContext context,
     Domain? domain,
   ) {
-    dynamic source = p0Value(pa0(map), methodMap, context, domain);
+    dynamic source = pa0Value(pa0(map), methodMap, context, domain);
 
     if (!(source is List)) {
       throw Exception('Sugar.mapEach has no valid source array');
     }
-
-    if (source is List) {
-      source = MapEachDomain(source, parent: domain).forEach(($, element) {
-        if (element is Map) {
-          if (element[tag] == null) {
-            return element; //直接返回Map对象
-          }
-          return convert(context, element, methodMap, domain: $);
-        } else {
-          return element;
-        }
-      });
-    }
-
     var children = [];
+
     //转为Widget
     if (source is List) {
-      children = MapEachDomain(source, parent: domain).forEach(($, _) {
-        return convert(context, pa1(map), methodMap, domain: $);
-      });
+      var itemBuilder = pa1(map);
+      // index, item
+      List functionParameters = FunctionDomain.pa(itemBuilder);
+      assert(functionParameters.length == 2, 'Sugar.mapEach 的域入参个数不对');
+
+      for (var i = 0; i < source.length; i++) {
+        var element = source[i];
+        children.add(
+          convert(
+            context,
+            itemBuilder,
+            methodMap,
+            domain: FunctionDomain(
+              {
+                functionParameters[0]: i,
+                functionParameters[1]: element,
+              },
+              parent: domain,
+            ),
+          ),
+        );
+      }
     }
     var params = {
       'pa': [source, children]
@@ -348,29 +385,34 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     BuildContext context,
     Domain? domain,
   ) {
-    dynamic source = p0Value(pa0(map), methodMap, context, domain);
+    dynamic source = pa0Value(pa0(map), methodMap, context, domain);
 
     if (!(source is List)) {
       throw Exception('Sugar.mapEach has no valid source array');
     }
 
-    if (source is List) {
-      source = MapEachDomain(source, parent: domain).forEach(($, element) {
-        if (element is Map) {
-          if (element[tag] == null) {
-            return element; //直接返回Map对象
-          }
-          return convert(context, element, methodMap, domain: $);
-        } else {
-          return element;
-        }
-      });
-    }
     var children = [];
     if (source is List) {
-      children = MapEachDomain(source, parent: domain).forEach(($, _) {
-        return convert(context, map['na']['builder'], methodMap, domain: $);
-      });
+      var itemBuilder = pa1(map);
+      // item
+      var functionParameters = FunctionDomain.pa(itemBuilder);
+      assert(functionParameters.length == 1, 'Sugar.map 的域入参个数不对');
+      for (var i = 0; i < source.length; i++) {
+        var element = source[i];
+        children.add(
+          convert(
+            context,
+            itemBuilder,
+            methodMap,
+            domain: FunctionDomain(
+              {
+                functionParameters[0]: element,
+              },
+              parent: domain,
+            ),
+          ),
+        );
+      }
     }
     var params = {
       'pa': [source, children]
@@ -388,7 +430,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     var source = pa1(map);
 
     if (caseValue != null) {
-      caseValue = p0Value(caseValue, methodMap, context, domain);
+      caseValue = pa0Value(caseValue, methodMap, context, domain);
     }
     if (!(source is List)) {
       throw Exception('Sugar.SwitchCase has no valid cases array');
@@ -397,14 +439,14 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     if (source is List) {
       for (var caseItem in source) {
         var na = caseItem['na'];
-        if (p0Value(na['sugarCase'], methodMap, context, domain) == caseValue) {
-          return p0Value(na['reValue'], methodMap, context, domain);
+        if (pa0Value(na['sugarCase'], methodMap, context, domain) == caseValue) {
+          return pa0Value(na['reValue'], methodMap, context, domain);
         }
       }
     }
 
     var defaultValue = pa2(map);
-    return p0Value(defaultValue, methodMap, context, domain);
+    return pa0Value(defaultValue, methodMap, context, domain);
   }
 
   PopupMenuButton _popupMenuBuilder(Function mapEach, Map map, Map? methodMap,
@@ -695,12 +737,12 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   ) {
     var na = map['na'];
 
-    var p0 = p0Value(pa0(map), methodMap, context, domain);
-    var p1 = p0Value(pa1(map), methodMap, context, domain);
+    var p0 = pa0Value(pa0(map), methodMap, context, domain);
+    var p1 = pa0Value(pa1(map), methodMap, context, domain);
     if (p0 == p1) {
-      return p0Value(na['trueValue'], methodMap, context, domain);
+      return pa0Value(na['trueValue'], methodMap, context, domain);
     } else {
-      return p0Value(na['falseValue'], methodMap, context, domain);
+      return pa0Value(na['falseValue'], methodMap, context, domain);
     }
   }
 
@@ -712,14 +754,14 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   ) {
     var na = map['na'];
 
-    if (p0Value(pa0(map), methodMap, context, domain)) {
-      return p0Value(na['trueValue'], methodMap, context, domain);
+    if (pa0Value(pa0(map), methodMap, context, domain)) {
+      return pa0Value(na['trueValue'], methodMap, context, domain);
     } else {
-      return p0Value(na['falseValue'], methodMap, context, domain);
+      return pa0Value(na['falseValue'], methodMap, context, domain);
     }
   }
 
-  dynamic p0Value(
+  dynamic pa0Value(
     dynamic input,
     Map? methodMap,
     BuildContext context,
@@ -730,5 +772,98 @@ class DynamicWidgetBuilder extends DynamicBuilder {
       list: pa.data,
     );
     return pa0(values);
+  }
+
+  dynamic _buildSugarNullableIndexedWidgetBuilder(
+      BuildContext context, Map map, Map? methodMap,
+      {Domain? domain}) {
+    dynamic source = pa0(map);
+    assert(source is Map);
+    List functionParameters = FunctionDomain.pa(source);            
+    NullableIndexedWidgetBuilder builder = (builderContext, index) {
+      return convert(
+        context,
+        source,
+        methodMap,
+        domain: FunctionDomain(
+          {
+            functionParameters[0]: builderContext,
+            functionParameters[1]: index,
+          },
+          parent: domain,
+        ),
+      );
+    };
+    return builder;
+  }
+
+  dynamic _buildSugarIndexedWidgetBuilder(
+      BuildContext context, Map map, Map? methodMap,
+      {Domain? domain}) {
+    dynamic source = pa0(map);
+    assert(source is Map);
+    List functionParameters = FunctionDomain.pa(source);            
+    IndexedWidgetBuilder builder = (builderContext, index) {
+      return convert(
+        context,
+        source,
+        methodMap,
+        domain: FunctionDomain(
+          {
+            functionParameters[0]: builderContext,
+            functionParameters[1]: index,
+          },
+          parent: domain,
+        ),
+      );
+    };
+    return builder;
+  }
+
+  dynamic _buildSugarWidgetBuilder(
+      BuildContext context, Map map, Map? methodMap,
+      {Domain? domain}) {
+    dynamic source = pa0(map);
+    assert(source is Map);
+    List functionParameters = FunctionDomain.pa(source);    
+    WidgetBuilder builder = (
+      builderContext,
+    ) {
+      return convert(
+        context,
+        source,
+        methodMap,
+        domain: FunctionDomain(
+          {
+            functionParameters[0]: builderContext,
+          },
+          parent: domain,
+        ),
+      );
+    };
+    return builder;
+  }
+
+  dynamic _buildSugarTransitionBuilder(
+      BuildContext context, Map map, Map? methodMap,
+      {Domain? domain}) {
+    dynamic source = pa0(map);
+    assert(source is Map);
+    List functionParameters = FunctionDomain.pa(source);    
+    TransitionBuilder builder = (builderContext, child) {
+      return convert(
+        context,
+        source,
+        methodMap,
+        domain: FunctionDomain(
+          {
+            functionParameters[0]: builderContext,
+            functionParameters[1]: child,
+          },
+          parent: domain,
+        ),
+      );
+    };
+    return builder;
   }
 }

--- a/fair/lib/src/render/builder.dart
+++ b/fair/lib/src/render/builder.dart
@@ -63,6 +63,34 @@ class DynamicWidgetBuilder extends DynamicBuilder {
         return _buildIfEqualBool(map, methodMap, context, domain);
       } else if (name == 'Sugar.switchCase') {
         return _buildSwitchCase(map, methodMap, context, domain);
+      } else if (name == 'Sugar.nullableIndexedWidgetBuilder') {
+        return _buildSugarNullableIndexedWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.indexedWidgetBuilder') {
+        return _buildSugarIndexedWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.widgetBuilder') {
+        return _buildSugarWidgetBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
+      } else if (name == 'Sugar.transitionBuilder') {
+        return _buildSugarTransitionBuilder(
+          context,
+          map,
+          methodMap,
+          domain: domain,
+        );
       }
 
       var module = bound?.modules?.moduleOf(name)?.call();
@@ -117,34 +145,6 @@ class DynamicWidgetBuilder extends DynamicBuilder {
       } else if (name == 'Sugar.sliverGridDelegateWithFixedCrossAxisCount') {
         return _buildSugarSliverGridDelegateWithFixedCrossAxisCount(
             mapper, map, methodMap, context);
-      } else if (name == 'Sugar.nullableIndexedWidgetBuilder') {
-        return _buildSugarNullableIndexedWidgetBuilder(
-          context,
-          map,
-          methodMap,
-          domain: domain,
-        );
-      } else if (name == 'Sugar.indexedWidgetBuilder') {
-        return _buildSugarIndexedWidgetBuilder(
-          context,
-          map,
-          methodMap,
-          domain: domain,
-        );
-      } else if (name == 'Sugar.widgetBuilder') {
-        return _buildSugarWidgetBuilder(
-          context,
-          map,
-          methodMap,
-          domain: domain,
-        );
-      } else if (name == 'Sugar.transitionBuilder') {
-        return _buildSugarTransitionBuilder(
-          context,
-          map,
-          methodMap,
-          domain: domain,
-        );
       }
 
       var source = map['mapEach'];

--- a/fair/lib/src/render/builder.dart
+++ b/fair/lib/src/render/builder.dart
@@ -87,14 +87,30 @@ class DynamicWidgetBuilder extends DynamicBuilder {
             name, domain, mapper, map, methodMap, context);
       } else if (name == 'Sugar.isNestedScrollViewHeaderSliversBuilder') {
         return _buildNestedScrollViewHeaderSlivers(
-            mapper, map, methodMap, context);
+          mapper,
+          map,
+          methodMap,
+          context,
+          domain,
+        );
       } else if (name == 'Sugar.isButtonStyle') {
         return _buildSugarButtonStyle(mapper, map, methodMap, context);
       } else if (name == 'Sugar.popMenuButton') {
-        return _popupMenuBuilder(mapper, map, methodMap, context);
+        return _popupMenuBuilder(
+          mapper,
+          map,
+          methodMap,
+          context,
+          domain,
+        );
       } else if (name == 'Sugar.sliverChildBuilderDelegate') {
         return _buildSugarSliverChildBuilderDelegate(
-            mapper, map, methodMap, context);
+          mapper,
+          map,
+          methodMap,
+          context,
+          domain,
+        );
       } else if (name == 'Sugar.sliverGridDelegateWithFixedCrossAxisCount') {
         return _buildSugarSliverGridDelegateWithFixedCrossAxisCount(
             mapper, map, methodMap, context);
@@ -102,7 +118,10 @@ class DynamicWidgetBuilder extends DynamicBuilder {
 
       var source = map['mapEach'];
       if (source != null && source is List) {
-        var children = Domain(source).forEach(($, _) {
+        var children = MapEachDomain(
+          source,
+          parent: domain,
+        ).forEach(($, _) {
           return block(map, methodMap, context, $, mapper, name, isWidget);
         });
         return children.asListOf<Widget>() ?? children;
@@ -297,7 +316,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     }
 
     if (source is List) {
-      source = Domain(source).forEach(($, element) {
+      source = MapEachDomain(source, parent: domain).forEach(($, element) {
         if (element is Map) {
           if (element[tag] == null) {
             return element; //直接返回Map对象
@@ -312,7 +331,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     var children = [];
     //转为Widget
     if (source is List) {
-      children = Domain(source).forEach(($, _) {
+      children = MapEachDomain(source, parent: domain).forEach(($, _) {
         return convert(context, pa1(map), methodMap, domain: $);
       });
     }
@@ -336,7 +355,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     }
 
     if (source is List) {
-      source = Domain(source).forEach(($, element) {
+      source = MapEachDomain(source, parent: domain).forEach(($, element) {
         if (element is Map) {
           if (element[tag] == null) {
             return element; //直接返回Map对象
@@ -349,7 +368,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     }
     var children = [];
     if (source is List) {
-      children = Domain(source).forEach(($, _) {
+      children = MapEachDomain(source, parent: domain).forEach(($, _) {
         return convert(context, map['na']['builder'], methodMap, domain: $);
       });
     }
@@ -388,8 +407,8 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     return p0Value(defaultValue, methodMap, context, domain);
   }
 
-  PopupMenuButton _popupMenuBuilder(
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
+  PopupMenuButton _popupMenuBuilder(Function mapEach, Map map, Map? methodMap,
+      BuildContext context, Domain? domain) {
     var propertyTransMap = Map.from(map);
     Map na = map['na'];
     var itemBuilder = na['itemBuilder'];
@@ -403,7 +422,8 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     }
     //第一次解析
     if (itemBuilder is List) {
-      var list = Domain(itemBuilder).forEach(($, element) {
+      var list =
+          MapEachDomain(itemBuilder, parent: domain).forEach(($, element) {
         return convert(context, element, methodMap, domain: $) as Widget;
       });
       var children = list.map((e) => e as PopupMenuEntry<Object>).toList();
@@ -416,8 +436,14 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     return mapEach.call(params);
   }
 
-  ListView _buildSugarListBuilder(String name, Domain? superDomain,
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
+  ListView _buildSugarListBuilder(
+    String name,
+    Domain? domain,
+    Function mapEach,
+    Map map,
+    Map? methodMap,
+    BuildContext context,
+  ) {
     var propertyTransMap = Map.from(map);
 
     var naOrMap = {};
@@ -427,8 +453,8 @@ class DynamicWidgetBuilder extends DynamicBuilder {
     var itemBuilder = naOrMap['itemBuilder'];
     naOrMap.remove('itemBuilder');
 
-    var na = named(name, naOrMap, methodMap, context, superDomain);
-    var pa = positioned(map['pa'], methodMap, context, superDomain);
+    var na = named(name, naOrMap, methodMap, context, domain);
+    var pa = positioned(map['pa'], methodMap, context, domain);
     Map naMap = Property.extract(list: pa.data, map: na.data);
 
     propertyTransMap['className'] = 'ListView';
@@ -437,7 +463,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
 
     var count = naMap['itemCount'];
     var source = List<int>.generate(count, (i) => i + 1);
-    var list = Domain(source).forEach(($, _) {
+    var list = MapEachDomain(itemBuilder, parent: domain).forEach(($, _) {
       return convert(context, itemBuilder, methodMap, domain: $) as Widget;
     });
     var children = list.map((e) => e as Widget).toList();
@@ -449,13 +475,17 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   }
 
   NestedScrollViewHeaderSliversBuilder _buildNestedScrollViewHeaderSlivers(
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
+      Function mapEach,
+      Map map,
+      Map? methodMap,
+      BuildContext context,
+      Domain? domain) {
     var na = map['na'];
     var innerBoxIsScrolled = na['innerBoxIsScrolled'];
     var headerSliverBuilder = na['headerSliverBuilder'];
     var source = List<int>.generate(headerSliverBuilder.length, (i) => i + 1);
 
-    var list = Domain(source).forEach(($, index) {
+    var list = MapEachDomain(source, parent: domain).forEach(($, index) {
       return convert(context, headerSliverBuilder[index - 1], methodMap,
           domain: $) as Widget;
     });
@@ -603,7 +633,11 @@ class DynamicWidgetBuilder extends DynamicBuilder {
   }
 
   SliverChildBuilderDelegate _buildSugarSliverChildBuilderDelegate(
-      Function mapEach, Map map, Map? methodMap, BuildContext context) {
+      Function mapEach,
+      Map map,
+      Map? methodMap,
+      BuildContext context,
+      Domain? domain) {
     Map na = map['na'];
     var childCount = na['childCount'];
     var builder = na['builder'];
@@ -624,7 +658,7 @@ class DynamicWidgetBuilder extends DynamicBuilder {
 
     var source = List<int>.generate(childCount, (i) => i + 1);
 
-    var list = Domain(source).forEach(($, _) {
+    var list = MapEachDomain(source, parent: domain).forEach(($, _) {
       //拿到所有itemBuilder对应的数组
       return convert(context, builderMap, methodMap, domain: $) as Widget;
     });

--- a/fair/lib/src/render/domain.dart
+++ b/fair/lib/src/render/domain.dart
@@ -4,7 +4,6 @@
  * found in the LICENSE file.
  */
 
-import 'package:fair/fair.dart';
 import 'base_model.dart';
 
 abstract class Domain {
@@ -22,6 +21,11 @@ abstract class IndexDomain extends Domain {
   int index = 0;
 }
 
+/// 暂时留着，适配之前的代码
+/// Sugar.popMenuButton
+/// Sugar.listBuilder 现在可以简单支持，看需要移除不
+/// Sugar.isNestedScrollViewHeaderSliversBuilder
+/// Sugar.sliverChildBuilderDelegate 现在可以简单支持，看需要移除不
 class MapEachDomain extends IndexDomain {
   MapEachDomain(this.source, {required Domain? parent}) : super(parent: parent);
 
@@ -29,76 +33,66 @@ class MapEachDomain extends IndexDomain {
 
   @override
   bool match(dynamic exp) {
-    if (parent != null && parent!.match(exp)) {
+    if (currentMatch(exp)) {
       return true;
     }
-    return (source != null &&
-        exp is String &&
-        ((RegExp('#\\(.+\\)', multiLine: true).hasMatch(exp) &&
-                (exp.contains('\$item') || exp.contains('\$index'))) ||
-            exp == 'item' ||
-            exp == 'index' ||
-            exp.startsWith("\$(item") ||
-            exp.startsWith("\$(index") ||
-            exp.startsWith("#(\${index") ||
-            exp.startsWith("#(\${item") ||
-            exp.startsWith('^(index)') ||
-            exp.startsWith('^(item)')));
+    return parentMatch(exp);
   }
 
   @override
   dynamic bindValue(String exp) {
-    if (parent != null && parent!.match(exp)) {
+    if (currentMatch(exp)) {
+      if (exp == 'item') {
+        return source?[index];
+      } else if (exp == 'index') {
+        return index;
+      }
+      // Carrying ”#(“ indicates value conversion to a string
+      final isStringValue = exp.startsWith('#(');
+      dynamic processed = exp.substring(2, exp.length - 1);
+      if (processed.startsWith('\${')) {
+        processed = processed.substring(2, processed.length - 1);
+      }
+
+      // ^(item)
+      if (processed == 'item') {
+        return source?[index];
+      }
+      // ^(index)
+      else if (processed == 'index') {
+        return index;
+      }
+
+      if (processed.contains('.')) {
+        List<String> expList = processed.split('.');
+        if (expList.first == '\$item' || expList.first == 'item') {
+          dynamic obj = source?[index];
+          dynamic modelValue;
+          if (obj is BaseModel) {
+            var json = (obj).toJson();
+            modelValue = json;
+          } else if (obj is Map) {
+            modelValue = obj;
+          }
+          if (modelValue != null) {
+            expList.removeAt(0);
+            for (var k in expList) {
+              modelValue = modelValue[k];
+            }
+            // If conversion to a string is not explicitly indicated, the original type is returned
+            processed = isStringValue ? '$modelValue' : modelValue;
+          }
+        }
+      } else {
+        processed = processed.replaceAll('\$item', '${source?[index]}');
+        processed = processed.replaceAll('\$index', '$index');
+      }
+
+      return processed;
+    } else if (parentMatch(exp)) {
       return parent!.bindValue(exp);
     }
-
-    if (exp == 'item') {
-      return source?[index];
-    } else if (exp == 'index') {
-      return index;
-    }
-    // Carrying ”#(“ indicates value conversion to a string
-    final bool isStringValue = exp.startsWith('#(');
-    dynamic processed = exp.substring(2, exp.length - 1);
-    if (processed.startsWith("\${")) {
-      processed = processed.substring(2, processed.length - 1);
-    }
-
-    // ^(item)
-    if (processed == 'item') {
-      return source?[index];
-    }
-    // ^(index)
-    else if (processed == 'index') {
-      return index;
-    }
-
-    if (processed.contains('.')) {
-      List<String> expList = processed.split('.');
-      if (expList.first == '\$item' || expList.first == 'item') {
-        dynamic obj = source?[index];
-        dynamic modelValue;
-        if (obj is BaseModel) {
-          Map<String, dynamic> json = (obj as BaseModel).toJson();
-          modelValue = json;
-        } else if (obj is Map) {
-          modelValue = obj;
-        }
-        if (modelValue != null) {
-          expList.removeAt(0);
-          for (String k in expList) {
-            modelValue = modelValue[k];
-          }
-          // If conversion to a string is not explicitly indicated, the original type is returned
-          processed = isStringValue ? "${modelValue}" : modelValue;
-        }
-      }
-    } else {
-      processed = processed.replaceAll('\$item', '${source?[index]}');
-      processed = processed.replaceAll('\$index', '$index');
-    }
-
-    return processed;
+    return exp;
   }
 
   List forEach(dynamic Function(Domain $, dynamic element) f) {
@@ -109,5 +103,133 @@ class MapEachDomain extends IndexDomain {
       index++;
     }
     return result;
+  }
+
+  bool currentMatch(exp) {
+    return (source != null &&
+        exp is String &&
+        ((RegExp('#\\(.+\\)', multiLine: true).hasMatch(exp) &&
+                (exp.contains('\$item') || exp.contains('\$index'))) ||
+            exp == 'item' ||
+            exp == 'index' ||
+            exp.startsWith('\$(item') ||
+            exp.startsWith('\$(index') ||
+            exp.startsWith('#(\${index') ||
+            exp.startsWith('#(\${item') ||
+            exp.startsWith('^(index)') ||
+            exp.startsWith('^(item)')));
+  }
+
+  bool parentMatch(exp) {
+    return parent?.match(exp) ?? false;
+  }
+}
+
+/// 通用的回调 Function 的域，用于替换域下面对应参数的值
+///
+///
+class FunctionDomain extends Domain {
+  FunctionDomain(this.parameters, {required Domain? parent})
+      : super(parent: parent);
+  Map<String, dynamic> parameters;
+
+  /// 获取 postion 参数
+  static List pa(Map map) {
+    return _getParameters(map, false);
+  }
+
+  /// 获取 named 参数
+  static List na(Map map) {
+    return _getParameters(map, true);
+  }
+
+  static List<dynamic> _getParameters(Map<dynamic, dynamic> map, bool isNamed) {
+    var parameters = map['functionParameters']?[isNamed ? 'na' : 'pa'];
+    return parameters ?? [];
+  }
+
+  @override
+  dynamic bindValue(String exp) {
+    if (currentMatch(exp)) {
+      for (var key in parameters.keys) {
+        if (key == exp) {
+          return parameters[key];
+        }
+      }
+
+      // Carrying ”#(“ indicates value conversion to a string
+      final isStringValue = exp.startsWith('#(');
+      dynamic processed = exp.substring(2, exp.length - 1);
+      if (processed.startsWith('\${')) {
+        processed = processed.substring(2, processed.length - 1);
+      }
+
+      for (var key in parameters.keys) {
+        if (key == processed) {
+          return parameters[key];
+        }
+      }
+
+      if (processed.contains('.')) {
+        List<String> expList = processed.split('.');
+
+        for (var key in parameters.keys) {
+          if (expList.first == '\$$key' || expList.first == key) {
+            dynamic obj = parameters[key];
+            dynamic modelValue;
+            if (obj is BaseModel) {
+              var json = obj.toJson();
+              modelValue = json;
+            } else if (obj is Map) {
+              modelValue = obj;
+            }
+            if (modelValue != null) {
+              expList.removeAt(0);
+              for (var k in expList) {
+                modelValue = modelValue[k];
+              }
+              // If conversion to a string is not explicitly indicated, the original type is returned
+              processed = isStringValue ? '$modelValue' : modelValue;
+            }
+          }
+        }
+      } else {
+        for (var key in parameters.keys) {
+          processed = processed.replaceAll('\$$key', '${parameters[key]}');
+        }
+      }
+      return processed;
+    } else if (parentMatch(exp)) {
+      return parent!.bindValue(exp);
+    }
+    return exp;
+  }
+
+  @override
+  bool match(exp) {
+    if (currentMatch(exp)) {
+      return true;
+    }
+    return parentMatch(exp);
+  }
+
+  bool currentMatch(exp) {
+    if (exp is String && parameters.isNotEmpty) {
+      for (var key in parameters.keys) {
+        if ((RegExp('#\\(.+\\)', multiLine: true).hasMatch(exp) &&
+                exp.contains('\$$key')) ||
+            exp == key ||
+            exp.startsWith('\$($key') ||
+            exp.startsWith('#(\${$key') ||
+            exp.startsWith('^($key)')) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool parentMatch(exp) {
+    return parent?.match(exp) ?? false;
   }
 }


### PR DESCRIPTION
1. 对 domain 进行了抽象，支持嵌套的 domain
2. 新增 FunctionDomain 通用domain，我们将不再根据 'index','item' 等特殊字符来进行 domain 中值的替换，而根据用户实际定义的名称进行匹配。
3.为回调 function 生成对应的参数供 FunctionDomain 使用 
```
 "functionParameters": {
  "pa": [
    "index",
    "item"
  ]
}    
```                                              
4. 新增 NullableIndexedWidgetBuilder，IndexedWidgetBuilder，WidgetBuilder，TransitionBuilder 常用的 sugar 支持

现在用户可以通过自定自己的 dynamicWidgetBuilder，支持任意回调。
``` dart
      FairApp(
        dynamicWidgetBuilder: (proxyMirror, page, bound, {bundle}) =>
            CustomDynamicWidgetBuilder(proxyMirror, page, bound,
                bundle: bundle),
      ),
```

``` dart
class CustomDynamicWidgetBuilder extends DynamicWidgetBuilder {
  CustomDynamicWidgetBuilder(
    super.proxyMirror,
    super.page,
    super.bound, {
    super.bundle,
  });

  @override
  dynamic convert(BuildContext context, Map map, Map? methodMap,
      {Domain? domain}) {
    var name = map[tag];
    if (name == 'SugarCommon.loadingMoreItemBuilder') {
      dynamic source = pa0(map);
      assert(source is Map);
      List functionParameters = FunctionDomain.pa(source);      
      LoadingMoreItemBuilder builder = (context, item, index) {
        return convert(
          context,
          source,
          methodMap,
          domain: FunctionDomain(
            {
              functionParameters[0]: context,
              functionParameters[1]: item,
              functionParameters[2]: index,
            },
            parent: domain,
          ),
        );
      };
      return builder;
    }

    return super.convert(
      context,
      map,
      methodMap,
      domain: domain,
    );
  }
}
```




