### PR TITLE
rollback expression valid 的判断

### DIFF
--- a/fair/lib/src/render/expression.dart
+++ b/fair/lib/src/render/expression.dart
@@ -23,11 +23,6 @@ class R {
   }
 
   bool valid() {
-    if (data is String) {
-      String strData = data as String;
-
-      return strData.length > 0;
-    }
     return data != null;
   }
 }


### PR DESCRIPTION
这个对字符串为空字符串的判断是有问题的，字段为空字符串是很正常的，比如 https://github.com/wuba/Fair/blob/924617e27dce0e8d07de543b4e788a8354021a31/fair/example/lib/src/page/plugins/permission/sample_permission_page.dart#L31

最好找当时提交这个修复的同学再核对一下