### PR TITLE
Update fair_ffi.cpp

### DIFF
--- a/fair/android/src/main/cpp/sdk/fair_ffi.cpp
+++ b/fair/android/src/main/cpp/sdk/fair_ffi.cpp
@@ -26,6 +26,9 @@ const char *invokeJSCommonFuncSync(char *args) {
     if (attach == 1) {
       del_env();
     }
+    env->DeleteLocalRef(clazz_fair_app);
+    env->DeleteLocalRef(javaArgs);
+    env->DeleteLocalRef(result);
     return resultString;
   }
   return "Fair为空";


### PR DESCRIPTION
Fix "local reference table overflow" exception that occurs when invokeJSCommonFuncSync is called multiple times