### PR TITLE
修改onload异步调用问题

### DIFF
--- a/fair/ios/Classes/FairDynamicJSPlugin/FairDartBridge.m
+++ b/fair/ios/Classes/FairDynamicJSPlugin/FairDartBridge.m
@@ -87,7 +87,7 @@ FairSingletonM(FairDartBridge);
                             return;
                         }
                     }
-                    callback(@"success");
+                    callback(@{@"status":@"success"});
                 }];
             }
         }

--- a/fair/lib/src/runtime/runtime_fair_delegate.dart
+++ b/fair/lib/src/runtime/runtime_fair_delegate.dart
@@ -121,5 +121,6 @@ abstract class RuntimeFairDelegate {
 
   void dispose() {
     runtime?.invokeMethod(pageName, 'onUnload', null);
+    runtime?.invokeMethod(pageName, 'releaseJS', null);
   }
 }


### PR DESCRIPTION
修复js onLoad方法异步调用，在parse解析控件时无法获取正确的js侧变量值，导致界面渲染异常的问题