### PR TITLE
修复onLoad方法异步调用问题

### DIFF
--- a/fair/lib/src/runtime/runtime_fair_delegate.dart
+++ b/fair/lib/src/runtime/runtime_fair_delegate.dart
@@ -116,7 +116,7 @@ abstract class RuntimeFairDelegate {
   }
 
   void didChangeDependencies() {
-    runtime?.invokeMethod(pageName, 'onLoad', null);
+    runtime?.invokeMethodSync(pageName, 'onLoad', null);
   }
 
   void dispose() {


### PR DESCRIPTION
修复js onLoad方法异步调用，在parse解析控件时无法获取正确的js侧变量值，导致界面渲染异常